### PR TITLE
fix(ci): let pushes to main finish instead of cancelling them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request runs are waste, but a push to main must always
+  # finish: release-plz releases from main, so cancelling here would let a
+  # commit reach crates.io unverified.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Everything that does not need a Docker daemon, so formatting and lint


### PR DESCRIPTION
`cancel-in-progress` keyed on `github.ref` is right for pull requests, where a superseded run is waste, but wrong for `main`: each push cancels the run before it.

Merging #120, #121 and #122 in quick succession left the first two CI runs on `main` **cancelled**, so those commits were never verified. Since release-plz releases from `main` — which is the reason the push-to-main trigger was added in #120 — a cancelled run there can let a commit reach crates.io unverified.

Pull request runs still cancel superseded runs exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RsS7oNWJsSHMkPVhaxzT41